### PR TITLE
avoid 2 deprecated Gradle configurations (compile and testRuntime)

### DIFF
--- a/harness/build.gradle
+++ b/harness/build.gradle
@@ -2,6 +2,6 @@ if (!hasProperty('mainClass')) {
     ext.mainClass = ''
 }
 dependencies {
-    compile 'org.jmonkeyengine:jme3-core:3.3.0-beta1'
+    implementation 'org.jmonkeyengine:jme3-core:3.3.0-beta1'
     implementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
 }

--- a/tests-lwjgl2/build.gradle
+++ b/tests-lwjgl2/build.gradle
@@ -3,11 +3,12 @@ if (!hasProperty('mainClass')) {
 }
 
 dependencies {
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.4.2')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.4.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
     testImplementation project(':harness')
     testImplementation project(':tests')
-    testRuntime 'org.jmonkeyengine:jme3-desktop:3.3.0-beta1'
+    testImplementation 'org.jmonkeyengine:jme3-core:3.3.0-beta1'
+    testRuntimeOnly 'org.jmonkeyengine:jme3-desktop:3.3.0-beta1'
     testImplementation 'org.jmonkeyengine:jme3-lwjgl:3.3.0-beta1'
     testImplementation 'org.jmonkeyengine:jme3-testdata:3.3.0-beta1'
 }

--- a/tests-lwjgl3/build.gradle
+++ b/tests-lwjgl3/build.gradle
@@ -3,13 +3,14 @@ if (!hasProperty('mainClass')) {
 }
 
 dependencies {
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.4.2')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.4.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
     testImplementation project(':harness')
     testImplementation project(':tests')
-    testRuntime 'org.jmonkeyengine:jme3-desktop:3.3.0-beta1'
-    testRuntime 'org.jmonkeyengine:jme3-lwjgl3:3.3.0-beta1'
-    testRuntime 'org.jmonkeyengine:jme3-testdata:3.3.0-beta1'
+    testImplementation 'org.jmonkeyengine:jme3-core:3.3.0-beta1'
+    testRuntimeOnly 'org.jmonkeyengine:jme3-desktop:3.3.0-beta1'
+    testRuntimeOnly 'org.jmonkeyengine:jme3-lwjgl3:3.3.0-beta1'
+    testRuntimeOnly 'org.jmonkeyengine:jme3-testdata:3.3.0-beta1'
 }
 
 test {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -4,12 +4,13 @@ if (!hasProperty('mainClass')) {
 
 dependencies {
     // Implementation as we also expose the lwjgl classes as main dependency.
-    implementation('org.junit.jupiter:junit-jupiter-api:5.4.2')
+    implementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
     implementation project(':harness')
 
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.4.2')
-    testRuntime 'org.jmonkeyengine:jme3-desktop:3.3.0-beta1'
-    testRuntime 'org.jmonkeyengine:jme3-lwjgl:3.3.0-beta1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    implementation 'org.jmonkeyengine:jme3-core:3.3.0-beta1'
+    testRuntimeOnly 'org.jmonkeyengine:jme3-desktop:3.3.0-beta1'
+    testRuntimeOnly 'org.jmonkeyengine:jme3-lwjgl:3.3.0-beta1'
 }
 
 test {


### PR DESCRIPTION
This eliminates some annoying warnings generated by Gradle v6.